### PR TITLE
Add ability to specify "tags" for a route

### DIFF
--- a/examples/Suave.Swagger.PetStoreAPi/Program.fs
+++ b/examples/Suave.Swagger.PetStoreAPi/Program.fs
@@ -32,11 +32,24 @@ and [<CLIMutable>] PetCategory =
   { Id:int
     Name:string }
 
+[<CLIMutable>]
+type SubtractionRequest =
+  { First:int
+    Second:int
+  }
+
+[<CLIMutable>]
+type SubtractionResult = { Result:int }
 
 let createCategory =
   JsonBody<PetCategory>(fun model -> MODEL { model with Id=(Random().Next()) })
 
+
+
 let subtract(a,b) = OK ((a-b).ToString())
+
+let subtractObj =
+  JsonBody<SubtractionRequest>(fun {First=a;Second=b} -> MODEL {Result=(a-b)})
 
 let findPetById id = 
   MODEL
@@ -72,6 +85,12 @@ let api =
 
       for route in getting <| urlFormat "/subtract/%d/%d" subtract do
         yield description Of route is "Subtracts two numbers"
+        yield route |> tag "maths"
+
+      for route in posting <| simpleUrl "/subtract" |> thenReturns subtractObj do
+        yield description Of route is "Subtracts two numbers"
+        yield route |> addResponse 200 "Subtraction result" (Some typeof<SubtractionResult>)
+        yield parameter "subtraction request" Of route (fun p -> { p with Type = (Some typeof<SubtractionRequest>); In=Body })
         yield route |> tag "maths"
 
       for route in posting <| urlFormat "/subtract/%d/%d" subtract do

--- a/examples/Suave.Swagger.PetStoreAPi/Program.fs
+++ b/examples/Suave.Swagger.PetStoreAPi/Program.fs
@@ -62,31 +62,38 @@ let api =
 //      // syntax 1
       for route in getting (simpleUrl "/time" |> thenReturns now) do
         yield description Of route is "What time is it ?"
+        yield route |> tag "time"
 
 //      // another syntax
       for route in getOf (path "/time2" >=> now) do
         yield description Of route is "What time is it 2 ?"
         yield urlTemplate Of route is "/time2"
+        yield route |> tag "time"
 
       for route in getting <| urlFormat "/subtract/%d/%d" subtract do
         yield description Of route is "Subtracts two numbers"
+        yield route |> tag "maths"
 
       for route in posting <| urlFormat "/subtract/%d/%d" subtract do
         yield description Of route is "Subtracts two numbers"
+        yield route |> tag "maths"
 
       for route in getting <| urlFormat "/pet/%d" findPetById do
         yield description Of route is "Search a pet by id"
         yield route |> addResponse 200 "The found pet" (Some typeof<Pet>)
         yield route |> supportsJsonAndXml
+        yield route |> tag "pets"
       
       for route in getting <| urlFormat "/category/%d" findCategoryById do
         yield description Of route is "Search a category by id"
         yield route |> addResponse 200 "The found category" (Some typeof<PetCategory>)
+        yield route |> tag "pets"
       
       for route in posting <| simpleUrl "/category" |> thenReturns createCategory do
         yield description Of route is "Create a category"
         yield route |> addResponse 200 "returns the create model with assigned Id" (Some typeof<PetCategory>)
         yield parameter "category model" Of route (fun p -> { p with Type = (Some typeof<PetCategory>); In=Body })
+        yield route |> tag "pets"
 
 //       Classic routes with manual documentation
 

--- a/src/Suave.Swagger/FunnyDsl.fs
+++ b/src/Suave.Swagger/FunnyDsl.fs
@@ -119,7 +119,11 @@ module FunnyDsl =
     
   let parameter (name:string) _ (route:DocBuildState) (f:ParamDescriptor->ParamDescriptor) =
     let p = name |> ParamDescriptor.Named |> f
-    route.Documents(fun doc -> { doc with Params = (p :: doc.Params) })
+    let m = 
+      match p.Type with
+      | Some t -> t :: route.Models
+      | None -> route.Models
+    { route with Models = m}.Documents(fun doc -> { doc with Params = (p :: doc.Params) })
 
   let getting (d:DocBuildState) = 
     { d with Current = { d.Current with WebPart=(GET >=> d.Current.WebPart) } }

--- a/src/Suave.Swagger/FunnyDsl.fs
+++ b/src/Suave.Swagger/FunnyDsl.fs
@@ -43,6 +43,20 @@ module FunnyDsl =
             }
     }
 
+  let tag (tag:string) (route:DocBuildState) =
+    { route
+        with 
+          Current = 
+            { route.Current 
+                with 
+                  Description =
+                    { route.Current.Description
+                        with
+                          Tags = tag :: route.Current.Description.Tags
+                    }
+            }
+    }
+
 //  let supportsJsonAndXml route =
 //    route
 //    |> produces "application/json" 

--- a/src/Suave.Swagger/Swagger.fs
+++ b/src/Suave.Swagger/Swagger.fs
@@ -101,12 +101,13 @@ module Swagger =
       OperationId: string
       Produces: string list
       Consumes: string list
+      Tags : string list
       Params: ParamDescriptor list
       Verb:HttpVerb
       Responses:IDictionary<int, ResponseDoc> }
     static member Empty =
       { Template=""; Description=""; Params=[]; Verb=Get; Summary=""
-        OperationId=""; Produces=[]; Responses=dict Seq.empty; Consumes=[] }
+        OperationId=""; Produces=[]; Responses=dict Seq.empty; Consumes=[]; Tags = [] }
   and ResponseDoc = 
     { Description:string
       Schema:ObjectDefinition option }
@@ -168,6 +169,7 @@ module Swagger =
       OperationId:string
       Consumes:string list
       Produces:string list
+      Tags:string list
       Parameters:ParamDefinition list
       Responses:IDictionary<int, ResponseDoc> }
   and ResponseDocConverter() =
@@ -499,6 +501,7 @@ module Swagger =
                           Responses = rs
                           Consumes = o.Consumes @ state.Consumes |> List.distinct
                           Produces = o.Produces @ state.Produces |> List.distinct
+                          Tags = o.Tags @ state.Tags |> List.distinct
                       }
               }
             Models=m
@@ -547,7 +550,8 @@ module Swagger =
                           Consumes=p.Consumes
                           Produces=p.Produces
                           Parameters=par
-                          Responses=p.Responses }
+                          Responses=p.Responses
+                          Tags=p.Tags }
                       yield p.Verb, pa
                   } |> dict
                 (k,vs)


### PR DESCRIPTION
I've added the ability to specify "tags" for a route - this allows for the grouping of API calls as I discussed in [this issue](https://github.com/rflechner/Suave.Swagger/issues/5).

Let me know if there is anything I've missed - and thanks for maintaining the repository - I've found it really useful!