### PR TITLE
Swagger json generated by default should be valid

### DIFF
--- a/src/Suave.Swagger/Swagger.fs
+++ b/src/Suave.Swagger/Swagger.fs
@@ -448,6 +448,9 @@ module Swagger =
   type DocBuildState =
     { SwaggerJsonPath:string
       SwaggerUiPath:string
+      BasePath:string
+      Host:string
+      Schemes:string list
       Description:ApiDescription
       Routes:WebPartDocumentation list
       Current:WebPartDocumentation
@@ -456,6 +459,9 @@ module Swagger =
     static member Of w =
       { Routes=[]
         Models=[]
+        BasePath=null
+        Host=null
+        Schemes=["http"]
         Current=WebPartDocumentation.Of w
         Id=Guid.NewGuid()
         Description=ApiDescription.Empty
@@ -559,7 +565,7 @@ module Swagger =
             | _ -> ()
 
         { Definitions=definitions
-          BasePath=null; Host=null; Schemes=["http"]
+          BasePath=__.BasePath; Host=__.Host; Schemes=__.Schemes
           Paths=paths
           Info=__.Description
           Swagger="2.0" }

--- a/src/Suave.Swagger/Swagger.fs
+++ b/src/Suave.Swagger/Swagger.fs
@@ -154,7 +154,7 @@ module Swagger =
   and Contact =
     { Name:string; Url:string; Email:string }
     static member Empty = 
-      { Name=""; Url=""; Email="" }
+      { Name=""; Url=""; Email=null }
   and LicenseInfos =
     { Name:string; Url:string }
     static member Empty = 
@@ -238,9 +238,6 @@ module Swagger =
           let d = unbox<ObjectDefinition>(value)
           
           writer.WriteStartObject()
-          
-          writer.WritePropertyName "id"
-          writer.WriteValue d.Id
 
           writer.WritePropertyName "type"
           writer.WriteValue "object"
@@ -303,7 +300,7 @@ module Swagger =
       Paths:IDictionary<Path,IDictionary<HttpVerb,PathDefinition>>
       Definitions:IDictionary<string,ObjectDefinition> }
     member __.ToJson() =
-      let settings = new JsonSerializerSettings()
+      let settings = new JsonSerializerSettings(NullValueHandling = NullValueHandling.Ignore)
       settings.ContractResolver <- new CamelCasePropertyNamesContractResolver()
       settings.Converters.Add(new ResponseDocConverter())
       settings.Converters.Add(new PropertyDefinitionConverter())
@@ -562,7 +559,7 @@ module Swagger =
             | _ -> ()
 
         { Definitions=definitions
-          BasePath=""; Host=""; Schemes=["http"]
+          BasePath=null; Host=null; Schemes=["http"]
           Paths=paths
           Info=__.Description
           Swagger="2.0" }


### PR DESCRIPTION
With some empty properties, generated json file did not pass the swagger validator:

```
email: "Object didn't pass validation for format email: "
basePath: "String does not match pattern ^/: "
host: "String does not match pattern ^[^{}/ :\\]+(?::\d+)?$: "
```
For these I have just set `null` as a default value and set JsonSerializing settings to ignore `null`

Moreover "id" is not allowed as an object property in definitions:

```
OBJECT_ADDITIONAL_PROPERTIES: "Additional properties not allowed: id"
````

I have removed the code generating it.