### PR TITLE
Support Guid

### DIFF
--- a/src/Suave.Swagger/Swagger.fs
+++ b/src/Suave.Swagger/Swagger.fs
@@ -335,6 +335,7 @@ module Swagger =
               typeof<byte list>, ("string", "binary")
               typeof<byte seq>, ("string", "binary")
               typeof<byte>, ("string", "byte")
+              typeof<Guid>, ("string", "string")
             ] |> dict
 
     type Type with


### PR DESCRIPTION
Having Guid type in my model I notice that an empty definition was created for it:

``` 
Guid:
  type: object
  properties: {}
```
I added Guid to typeFormatNames dictionary to be created as a string instead.

There is "MapType" in Swashbuckle but that would need some refactoring or mutable https://github.com/domaindrivendev/Swashbuckle/issues/943